### PR TITLE
Added Ably (Internet of things) and corrected URLs for influxdb and questdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,8 +302,8 @@ You can read more about this distinction on Prof. Daniel Abadi's blog: [Distingu
 * [Chronix](http://chronix.io/) - a time series storage built to store time series highly compressed and for fast access times.
 * [Cube](http://square.github.io/cube/) - uses MongoDB to store time series data.
 * [Heroic](https://spotify.github.io/heroic/#!/index) - is a scalable time series database based on Cassandra and Elasticsearch.
-* [InfluxDB](https://questdb.io/) - a time series database with optimised IO and queries, supports pgsql and influx wire protocols.
-* [QuestDB](https://www.influxdata.com/) - distributed time series database.
+* [InfluxDB](https://www.influxdata.com/) - distributed time series database.
+* [QuestDB](https://questdb.io/) - time series database with optimised IO and queries, supports pgsql and influx wire protocol.
 * [IronDB](https://www.circonus.com/irondb/) - scalable, general-purpose time series database.
 * [Kairosdb](https://github.com/kairosdb/kairosdb) - similar to OpenTSDB but allows for Cassandra.
 * [M3DB](http://m3db.github.io/m3/m3db/) - a distributed time series database that can be used for storing realtime metrics at long retention.
@@ -683,6 +683,7 @@ You can read more about this distinction on Prof. Daniel Abadi's blog: [Distingu
 * [IFTTT](https://ifttt.com/) - If this then that
 * [Evrything](https://evrythng.com/)- Making products smart
 * [NetLytics](https://github.com/marty90/netlytics/) - Analytics platform to process network data on Spark.
+* [Ably](https://ably.com/) - Pub/sub messaging platform for IoT 
 
 ## Interesting Readings
 


### PR DESCRIPTION
Added Ably under Internet of things
Corrected URLs and descriptions for QuestDB and InfluxDB (there was a mismatch)